### PR TITLE
PrettyJSONSerializer

### DIFF
--- a/betamax/serializers/__init__.py
+++ b/betamax/serializers/__init__.py
@@ -3,11 +3,12 @@
 serializer_registry = {}
 
 from .base import BaseSerializer
-from .json_serializer import JSONSerializer
+from .json_serializer import JSONSerializer, PrettyJSONSerializer
 from .proxy import SerializerProxy
 
-_serializers = [JSONSerializer]
+_serializers = [JSONSerializer, PrettyJSONSerializer]
 serializer_registry.update(dict((s.name, s()) for s in _serializers))
 del _serializers
 
-__all__ = ['BaseSerializer', 'JSONSerializer', 'SerializerProxy']
+__all__ = ['BaseSerializer', 'JSONSerializer', 'PrettyJSONSerializer',
+           'SerializerProxy']

--- a/betamax/serializers/json_serializer.py
+++ b/betamax/serializers/json_serializer.py
@@ -23,3 +23,12 @@ class JSONSerializer(BaseSerializer):
             deserialized_data = {}
 
         return deserialized_data
+
+
+class PrettyJSONSerializer(JSONSerializer):
+    # Serializes and deserializes a cassette to pretty JSON
+    name = 'prettyjson'
+
+    def serialize(self, cassette_data):
+        return json.dumps(
+            cassette_data, sort_keys=True, indent=2, separators=(',', ': '))

--- a/tests/unit/test_serializers.py
+++ b/tests/unit/test_serializers.py
@@ -1,7 +1,8 @@
 import pytest
 import unittest
 
-from betamax.serializers import BaseSerializer, JSONSerializer
+from betamax.serializers import (
+    BaseSerializer, JSONSerializer, PrettyJSONSerializer)
 
 
 class TestJSONSerializer(unittest.TestCase):
@@ -16,6 +17,24 @@ class TestJSONSerializer(unittest.TestCase):
 
     def test_generate_cassette_name_with_instance(self):
         serializer = JSONSerializer()
+        assert ('fake_dir/cassette_name.json' ==
+                serializer.generate_cassette_name(self.cassette_dir,
+                                                  self.cassette_name))
+
+
+class TestPrettyJSONSerializer(unittest.TestCase):
+    def setUp(self):
+        self.cassette_dir = 'fake_dir'
+        self.cassette_name = 'cassette_name'
+
+    def test_generate_cassette_name(self):
+        serializer_cls = PrettyJSONSerializer
+        assert ('fake_dir/cassette_name.json' ==
+                serializer_cls.generate_cassette_name(self.cassette_dir,
+                                                      self.cassette_name))
+
+    def test_generate_cassette_name_with_instance(self):
+        serializer = PrettyJSONSerializer()
         assert ('fake_dir/cassette_name.json' ==
                 serializer.generate_cassette_name(self.cassette_dir,
                                                   self.cassette_name))


### PR DESCRIPTION
The default JSON serializer's output is hard to inspect and compare using non-JSON-aware tools, such as `git diff`. I've added `PrettyJSONSerializer` (named `prettyjson`) which outputs prettified key-sorted JSON.

I didn't add tests for the serialization because `JSONSerializer` doesn't seem to have any and I'm not sure how best to construct suitable data to round-trip through the serializer. I'm happy to add some for both `JSONSerializer` and `PrettyJSONSerializer` if you can suggest how to do that.

I also didn't update the documentation because I didn't see an obvious place to mention the new serializer. If you can point me at where that should be, I'm happy to do so.