### PR TITLE
Make __all__ immutable.

### DIFF
--- a/betamax/cassette/__init__.py
+++ b/betamax/cassette/__init__.py
@@ -2,4 +2,4 @@ from .cassette import Cassette
 from .interaction import Interaction
 from .mock_response import MockHTTPResponse
 
-__all__ = ['Cassette', 'Interaction', 'MockHTTPResponse']
+__all__ = ('Cassette', 'Interaction', 'MockHTTPResponse')

--- a/betamax/matchers/__init__.py
+++ b/betamax/matchers/__init__.py
@@ -11,9 +11,9 @@ from .query import QueryMatcher
 from .uri import URIMatcher
 
 
-__all__ = ['BaseMatcher', 'BodyMatcher', 'DigestAuthMatcher',
+__all__ = ('BaseMatcher', 'BodyMatcher', 'DigestAuthMatcher',
            'HeadersMatcher', 'HostMatcher', 'MethodMatcher', 'PathMatcher',
-           'QueryMatcher', 'URIMatcher']
+           'QueryMatcher', 'URIMatcher')
 
 
 _matchers = [BodyMatcher, DigestAuthMatcher, HeadersMatcher, HostMatcher,

--- a/betamax/serializers/__init__.py
+++ b/betamax/serializers/__init__.py
@@ -10,4 +10,4 @@ _serializers = [JSONSerializer]
 serializer_registry.update(dict((s.name, s()) for s in _serializers))
 del _serializers
 
-__all__ = ['BaseSerializer', 'JSONSerializer', 'SerializerProxy']
+__all__ = ('BaseSerializer', 'JSONSerializer', 'SerializerProxy')


### PR DESCRIPTION
Silences three of the warnings in the pep257 check by changing `__all__` to be immutable tuples, in line with the top level package.