### PR TITLE
add preserve_exact_body_bytes to docstring

### DIFF
--- a/betamax/configure.py
+++ b/betamax/configure.py
@@ -52,6 +52,7 @@ class Configuration(object):
         - ``placeholders``
         - ``re_record_interval``
         - ``record_mode``
+        - ``preserve_exact_body_bytes``
 
         Other options will be ignored.
         """


### PR DESCRIPTION
Should I also include the default value (in parens or otherwise) for these options so they show up [here](https://betamax.readthedocs.org/en/latest/api.html#betamax.configure.Configuration.default_cassette_options)?