### PR TITLE
Use byte string as default in BodyMatcher

### DIFF
--- a/betamax/matchers/body.py
+++ b/betamax/matchers/body.py
@@ -9,4 +9,4 @@ class BodyMatcher(BaseMatcher):
 
     def match(self, request, recorded_request):
         recorded_request = deserialize_prepared_request(recorded_request)
-        return recorded_request.body == (request.body or '')
+        return recorded_request.body == (request.body or b'')

--- a/tests/unit/test_matchers.py
+++ b/tests/unit/test_matchers.py
@@ -49,7 +49,7 @@ class TestMatchers(unittest.TestCase):
             'method': 'GET',
         })
         assert match(self.p, {
-            'body': '',
+            'body': b'',
             'headers': {'User-Agent': 'betamax/test'},
             'uri': 'http://example.com/path/to/end/point?query=string',
             'method': 'GET',
@@ -66,7 +66,7 @@ class TestMatchers(unittest.TestCase):
             'method': 'GET',
         }) is False
         assert match(p, {
-            'body': '',
+            'body': b'',
             'headers': {'User-Agent': 'betamax/test'},
             'uri': 'http://example.com/path/to/end/point?query=string',
             'method': 'GET',


### PR DESCRIPTION
I was having an issue between python2 and python3 that this appears to have solved. This works for python2 because:

    >>> b'' == ''
    True

The same is not true for python3 where `recorded_request.body` is a byte-string.