### PR TITLE
Fix #58: Attach cookies to response object

### DIFF
--- a/betamax/cassette/interaction.py
+++ b/betamax/cassette/interaction.py
@@ -1,5 +1,6 @@
 from .util import (deserialize_response, deserialize_prepared_request,
                    from_list)
+from requests.cookies import extract_cookies_to_jar
 from datetime import datetime
 
 
@@ -34,6 +35,7 @@ class Interaction(object):
         """Turn a serialized interaction into a Response."""
         r = deserialize_response(self.json['response'])
         r.request = deserialize_prepared_request(self.json['request'])
+        extract_cookies_to_jar(r.cookies, r.request, r.raw)
         self.recorded_at = datetime.strptime(
             self.json['recorded_at'], '%Y-%m-%dT%H:%M:%S'
         )

--- a/tests/unit/test_cassette.py
+++ b/tests/unit/test_cassette.py
@@ -338,6 +338,13 @@ class TestInteraction(unittest.TestCase):
         headers = dict((k, v[0]) for k, v in self.response['headers'].items())
         assert headers == r.headers
 
+        tested_cookie = False
+        for cookie in r.cookies:
+            cookie_str = "{0}={1}".format(cookie.name, cookie.value)
+            assert cookie_str == r.headers['Set-Cookie']
+            tested_cookie = True
+        assert tested_cookie
+
         assert self.response['body']['string'] == decode(r.content)
         actual_req = r.request
         expected_req = self.request


### PR DESCRIPTION
This provides a fix to issue #58 by using the `extract_cookies_to_jar` method from `requests` on the `response` object.