### PR TITLE
Fix #58 Serialize response cookies if they exist

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,3 +17,4 @@ Contributors
 ------------
 
 - Marc Abramowitz (@msabramo)
+- Bryce Boe <bbzbryce@gmail.com>

--- a/betamax/cassette/interaction.py
+++ b/betamax/cassette/interaction.py
@@ -35,7 +35,8 @@ class Interaction(object):
         """Turn a serialized interaction into a Response."""
         r = deserialize_response(self.json['response'])
         r.request = deserialize_prepared_request(self.json['request'])
-        extract_cookies_to_jar(r.cookies, r.request, r.raw)
+        if not r.cookies:  # Load from headers only for backwards compatability
+            extract_cookies_to_jar(r.cookies, r.request, r.raw)
         self.recorded_at = datetime.strptime(
             self.json['recorded_at'], '%Y-%m-%dT%H:%M:%S'
         )


### PR DESCRIPTION
I think this addition is now sufficient to resolve issue #58 as response cookies are now serialized with the cassette.