### PR TITLE
Improve error message if cassettes dir does not exist

### DIFF
--- a/betamax/exceptions.py
+++ b/betamax/exceptions.py
@@ -4,3 +4,7 @@ class BetamaxError(Exception):
 
     def __repr__(self):
         return 'BetamaxError("%s")' % self.message
+
+
+class MissingDirectoryError(BetamaxError):
+    pass

--- a/betamax/serializers/proxy.py
+++ b/betamax/serializers/proxy.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from .base import BaseSerializer
+from betamax.exceptions import MissingDirectoryError
 
 import os
 
@@ -27,6 +28,12 @@ class SerializerProxy(BaseSerializer):
         self.cassette_path = cassette_path
 
     def _ensure_path_exists(self):
+        directory, _ = os.path.split(self.cassette_path)
+        if not (directory == '' or os.path.isdir(directory)):
+            raise MissingDirectoryError(
+                'Configured cassette directory \'{0}\' does not exist - try '
+                'creating it'.format(directory)
+                )
         if not os.path.exists(self.cassette_path):
             open(self.cassette_path, 'w+').close()
 


### PR DESCRIPTION
Previously, the error message would be along the lines of:

    IOError: [Errno 2] No such file or directory: 'vcr/cassettes/test.json'

which isn't too helpful. After this patch, it now raises:

    MissingDirectoryError: Configured cassette directory "vcr/cassettes" does not exist - try creating it