### PR TITLE
Specify patterns for recursive-include directives

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,7 +2,7 @@ include README.rst
 include LICENSE
 include HISTORY.rst
 include AUTHORS.rst
-recursive-include docs/
-recursive-include tests/
+recursive-include docs Makefile *.py *.rst
+recursive-include tests *.json *.py
 prune *.pyc
 prune docs/_build


### PR DESCRIPTION
Hello,
without listing patterns it seems that MANIFEST.in is not used correctly.

This is the output of `python setup.py sdist` on `master` branch:
```
running sdist
running egg_info
writing requirements to betamax.egg-info/requires.txt
writing betamax.egg-info/PKG-INFO
writing top-level names to betamax.egg-info/top_level.txt
writing dependency_links to betamax.egg-info/dependency_links.txt
writing entry points to betamax.egg-info/entry_points.txt
writing manifest file 'betamax.egg-info/SOURCES.txt'
reading manifest file 'betamax.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: manifest_maker: MANIFEST.in, line 5: 'recursive-include' expects <dir> <pattern1> <pattern2> ...

warning: manifest_maker: MANIFEST.in, line 6: 'recursive-include' expects <dir> <pattern1> <pattern2> ...

no previously-included directories found matching '*.pyc'
no previously-included directories found matching 'docs/_build'
writing manifest file 'betamax.egg-info/SOURCES.txt'
running check
creating betamax-0.5.1
creating betamax-0.5.1/betamax
creating betamax-0.5.1/betamax.egg-info
creating betamax-0.5.1/betamax/cassette
creating betamax-0.5.1/betamax/fixtures
creating betamax-0.5.1/betamax/matchers
creating betamax-0.5.1/betamax/serializers
making hard links in betamax-0.5.1...
hard linking AUTHORS.rst -> betamax-0.5.1
hard linking HISTORY.rst -> betamax-0.5.1
hard linking LICENSE -> betamax-0.5.1
hard linking MANIFEST.in -> betamax-0.5.1
hard linking README.rst -> betamax-0.5.1
hard linking setup.cfg -> betamax-0.5.1
hard linking setup.py -> betamax-0.5.1
hard linking betamax/__init__.py -> betamax-0.5.1/betamax
hard linking betamax/adapter.py -> betamax-0.5.1/betamax
hard linking betamax/configure.py -> betamax-0.5.1/betamax
hard linking betamax/decorator.py -> betamax-0.5.1/betamax
hard linking betamax/exceptions.py -> betamax-0.5.1/betamax
hard linking betamax/options.py -> betamax-0.5.1/betamax
hard linking betamax/recorder.py -> betamax-0.5.1/betamax
hard linking betamax.egg-info/PKG-INFO -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/SOURCES.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/dependency_links.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/entry_points.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/requires.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/top_level.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax/cassette/__init__.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/cassette.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/headers.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/interaction.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/mock_response.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/util.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/fixtures/__init__.py -> betamax-0.5.1/betamax/fixtures
hard linking betamax/fixtures/pytest.py -> betamax-0.5.1/betamax/fixtures
hard linking betamax/fixtures/unittest.py -> betamax-0.5.1/betamax/fixtures
hard linking betamax/matchers/__init__.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/base.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/body.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/digest_auth.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/headers.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/host.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/method.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/path.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/query.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/uri.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/serializers/__init__.py -> betamax-0.5.1/betamax/serializers
hard linking betamax/serializers/base.py -> betamax-0.5.1/betamax/serializers
hard linking betamax/serializers/json_serializer.py -> betamax-0.5.1/betamax/serializers
hard linking betamax/serializers/proxy.py -> betamax-0.5.1/betamax/serializers
copying setup.cfg -> betamax-0.5.1
Writing betamax-0.5.1/setup.cfg
Creating tar archive
removing 'betamax-0.5.1' (and everything under it)
```
both *tests* and *docs* directories are missing.

Here the same, with the updated directives:
```
running sdist
running egg_info
writing requirements to betamax.egg-info/requires.txt
writing betamax.egg-info/PKG-INFO
writing top-level names to betamax.egg-info/top_level.txt
writing dependency_links to betamax.egg-info/dependency_links.txt
writing entry points to betamax.egg-info/entry_points.txt
reading manifest file 'betamax.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
no previously-included directories found matching '*.pyc'
no previously-included directories found matching 'docs/_build'
writing manifest file 'betamax.egg-info/SOURCES.txt'
running check
creating betamax-0.5.1
creating betamax-0.5.1/betamax
creating betamax-0.5.1/betamax.egg-info
creating betamax-0.5.1/betamax/cassette
creating betamax-0.5.1/betamax/fixtures
creating betamax-0.5.1/betamax/matchers
creating betamax-0.5.1/betamax/serializers
creating betamax-0.5.1/docs
creating betamax-0.5.1/tests
creating betamax-0.5.1/tests/cassettes
creating betamax-0.5.1/tests/integration
creating betamax-0.5.1/tests/regression
creating betamax-0.5.1/tests/unit
making hard links in betamax-0.5.1...
hard linking AUTHORS.rst -> betamax-0.5.1
hard linking HISTORY.rst -> betamax-0.5.1
hard linking LICENSE -> betamax-0.5.1
hard linking MANIFEST.in -> betamax-0.5.1
hard linking README.rst -> betamax-0.5.1
hard linking setup.cfg -> betamax-0.5.1
hard linking setup.py -> betamax-0.5.1
hard linking betamax/__init__.py -> betamax-0.5.1/betamax
hard linking betamax/adapter.py -> betamax-0.5.1/betamax
hard linking betamax/configure.py -> betamax-0.5.1/betamax
hard linking betamax/decorator.py -> betamax-0.5.1/betamax
hard linking betamax/exceptions.py -> betamax-0.5.1/betamax
hard linking betamax/options.py -> betamax-0.5.1/betamax
hard linking betamax/recorder.py -> betamax-0.5.1/betamax
hard linking betamax.egg-info/PKG-INFO -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/SOURCES.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/dependency_links.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/entry_points.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/requires.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/top_level.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax/cassette/__init__.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/cassette.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/headers.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/interaction.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/mock_response.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/util.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/fixtures/__init__.py -> betamax-0.5.1/betamax/fixtures
hard linking betamax/fixtures/pytest.py -> betamax-0.5.1/betamax/fixtures
hard linking betamax/fixtures/unittest.py -> betamax-0.5.1/betamax/fixtures
hard linking betamax/matchers/__init__.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/base.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/body.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/digest_auth.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/headers.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/host.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/method.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/path.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/query.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/uri.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/serializers/__init__.py -> betamax-0.5.1/betamax/serializers
hard linking betamax/serializers/base.py -> betamax-0.5.1/betamax/serializers
hard linking betamax/serializers/json_serializer.py -> betamax-0.5.1/betamax/serializers
hard linking betamax/serializers/proxy.py -> betamax-0.5.1/betamax/serializers
hard linking docs/Makefile -> betamax-0.5.1/docs
hard linking docs/api.rst -> betamax-0.5.1/docs
hard linking docs/cassettes.rst -> betamax-0.5.1/docs
hard linking docs/conf.py -> betamax-0.5.1/docs
hard linking docs/configuring.rst -> betamax-0.5.1/docs
hard linking docs/implementation_details.rst -> betamax-0.5.1/docs
hard linking docs/index.rst -> betamax-0.5.1/docs
hard linking docs/integrations.rst -> betamax-0.5.1/docs
hard linking docs/introduction.rst -> betamax-0.5.1/docs
hard linking docs/long_term_usage.rst -> betamax-0.5.1/docs
hard linking docs/matchers.rst -> betamax-0.5.1/docs
hard linking docs/record_modes.rst -> betamax-0.5.1/docs
hard linking docs/serializers.rst -> betamax-0.5.1/docs
hard linking docs/third_party_packages.rst -> betamax-0.5.1/docs
hard linking docs/usage_patterns.rst -> betamax-0.5.1/docs
hard linking tests/__init__.py -> betamax-0.5.1/tests
hard linking tests/conftest.py -> betamax-0.5.1/tests
hard linking tests/cassettes/GitHub_create_issue.json -> betamax-0.5.1/tests/cassettes
hard linking tests/cassettes/GitHub_emojis.json -> betamax-0.5.1/tests/cassettes
hard linking tests/cassettes/global_preserve_exact_body_bytes.json -> betamax-0.5.1/tests/cassettes
hard linking tests/cassettes/handles_digest_auth.json -> betamax-0.5.1/tests/cassettes
hard linking tests/cassettes/once_record_mode.json -> betamax-0.5.1/tests/cassettes
hard linking tests/cassettes/preserve_exact_bytes.json -> betamax-0.5.1/tests/cassettes
hard linking tests/cassettes/test-multiple-cookies-regression.json -> betamax-0.5.1/tests/cassettes
hard linking tests/cassettes/test.json -> betamax-0.5.1/tests/cassettes
hard linking tests/cassettes/tests.integration.test_fixtures.TestPyTestFixtures.test_pytest_fixture.json -> betamax-0.5.1/tests/cassettes
hard linking tests/integration/__init__.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/helper.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_backwards_compat.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_fixtures.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_multiple_cookies.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_placeholders.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_preserve_exact_body_bytes.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_record_modes.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_unicode.py -> betamax-0.5.1/tests/integration
hard linking tests/regression/test_cassettes_retain_global_configuration.py -> betamax-0.5.1/tests/regression
hard linking tests/regression/test_gzip_compression.py -> betamax-0.5.1/tests/regression
hard linking tests/regression/test_once_prevents_new_interactions.py -> betamax-0.5.1/tests/regression
hard linking tests/regression/test_works_with_digest_auth.py -> betamax-0.5.1/tests/regression
hard linking tests/unit/test_adapter.py -> betamax-0.5.1/tests/unit
hard linking tests/unit/test_betamax.py -> betamax-0.5.1/tests/unit
hard linking tests/unit/test_cassette.py -> betamax-0.5.1/tests/unit
hard linking tests/unit/test_configure.py -> betamax-0.5.1/tests/unit
hard linking tests/unit/test_decorator.py -> betamax-0.5.1/tests/unit
hard linking tests/unit/test_fixtures.py -> betamax-0.5.1/tests/unit
hard linking tests/unit/test_matchers.py -> betamax-0.5.1/tests/unit
hard linking tests/unit/test_options.py -> betamax-0.5.1/tests/unit
hard linking tests/unit/test_recorder.py -> betamax-0.5.1/tests/unit
hard linking tests/unit/test_serializers.py -> betamax-0.5.1/tests/unit
copying setup.cfg -> betamax-0.5.1
Writing betamax-0.5.1/setup.cfg
Creating tar archive
removing 'betamax-0.5.1' (and everything under it)
```
*docs* and *tests* directories are included.

The following is the output using `0.5.1` tag:
```
running sdist
running egg_info
writing requirements to betamax.egg-info/requires.txt
writing betamax.egg-info/PKG-INFO
writing top-level names to betamax.egg-info/top_level.txt
writing dependency_links to betamax.egg-info/dependency_links.txt
writing entry points to betamax.egg-info/entry_points.txt
writing manifest file 'betamax.egg-info/SOURCES.txt'
reading manifest file 'betamax.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
warning: manifest_maker: MANIFEST.in, line 5: 'recursive-include' expects <dir> <pattern1> <pattern2> ...

warning: manifest_maker: MANIFEST.in, line 6: 'recursive-include' expects <dir> <pattern1> <pattern2> ...

no previously-included directories found matching '*.pyc'
no previously-included directories found matching 'docs/_build'
writing manifest file 'betamax.egg-info/SOURCES.txt'
running check
creating betamax-0.5.1
creating betamax-0.5.1/betamax
creating betamax-0.5.1/betamax.egg-info
creating betamax-0.5.1/betamax/cassette
creating betamax-0.5.1/betamax/fixtures
creating betamax-0.5.1/betamax/matchers
creating betamax-0.5.1/betamax/serializers
creating betamax-0.5.1/tests
creating betamax-0.5.1/tests/integration
making hard links in betamax-0.5.1...
hard linking AUTHORS.rst -> betamax-0.5.1
hard linking HISTORY.rst -> betamax-0.5.1
hard linking LICENSE -> betamax-0.5.1
hard linking MANIFEST.in -> betamax-0.5.1
hard linking README.rst -> betamax-0.5.1
hard linking setup.py -> betamax-0.5.1
hard linking betamax/__init__.py -> betamax-0.5.1/betamax
hard linking betamax/adapter.py -> betamax-0.5.1/betamax
hard linking betamax/configure.py -> betamax-0.5.1/betamax
hard linking betamax/decorator.py -> betamax-0.5.1/betamax
hard linking betamax/exceptions.py -> betamax-0.5.1/betamax
hard linking betamax/options.py -> betamax-0.5.1/betamax
hard linking betamax/recorder.py -> betamax-0.5.1/betamax
hard linking betamax.egg-info/PKG-INFO -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/SOURCES.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/dependency_links.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/entry_points.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/requires.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax.egg-info/top_level.txt -> betamax-0.5.1/betamax.egg-info
hard linking betamax/cassette/__init__.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/cassette.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/headers.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/interaction.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/mock_response.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/cassette/util.py -> betamax-0.5.1/betamax/cassette
hard linking betamax/fixtures/__init__.py -> betamax-0.5.1/betamax/fixtures
hard linking betamax/fixtures/pytest.py -> betamax-0.5.1/betamax/fixtures
hard linking betamax/fixtures/unittest.py -> betamax-0.5.1/betamax/fixtures
hard linking betamax/matchers/__init__.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/base.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/body.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/digest_auth.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/headers.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/host.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/method.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/path.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/query.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/matchers/uri.py -> betamax-0.5.1/betamax/matchers
hard linking betamax/serializers/__init__.py -> betamax-0.5.1/betamax/serializers
hard linking betamax/serializers/base.py -> betamax-0.5.1/betamax/serializers
hard linking betamax/serializers/json_serializer.py -> betamax-0.5.1/betamax/serializers
hard linking betamax/serializers/proxy.py -> betamax-0.5.1/betamax/serializers
hard linking tests/integration/__init__.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/helper.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_backwards_compat.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_fixtures.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_multiple_cookies.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_placeholders.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_preserve_exact_body_bytes.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_record_modes.py -> betamax-0.5.1/tests/integration
hard linking tests/integration/test_unicode.py -> betamax-0.5.1/tests/integration
Writing betamax-0.5.1/setup.cfg
Creating tar archive
removing 'betamax-0.5.1' (and everything under it)
```
*docs* directory is missing and only `tests/integration/*.py` is included. I did not investigate why this happen but updating `recursive-include` directives fix the problem.

The PyPI tarball for 0.5.1 release contains only `tests/integration`.