### PR TITLE
Allow merging of cassette placeholder overrides

### DIFF
--- a/betamax/adapter.py
+++ b/betamax/adapter.py
@@ -60,7 +60,7 @@ class BetamaxAdapter(BaseAdapter):
         self.cassette_name = cassette_name
         self.serialize = serialize
         self.options.update(options.items())
-        placeholders = self.options.get('placeholders', [])
+        placeholders = self.options.get('placeholders', {})
 
         default_options = Cassette.default_cassette_options
 

--- a/betamax/cassette/cassette.py
+++ b/betamax/cassette/cassette.py
@@ -17,7 +17,7 @@ class Cassette(object):
         'record_mode': 'once',
         'match_requests_on': ['method', 'uri'],
         're_record_interval': None,
-        'placeholders': [],
+        'placeholders': {},
         'preserve_exact_body_bytes': False
     }
 
@@ -41,6 +41,9 @@ class Cassette(object):
 
         # Determine which placeholders to use
         self.placeholders = kwargs.get('placeholders')
+        if isinstance(self.placeholders, list):
+            self.placeholders = dict((ph['placeholder'], ph['replace'])
+                                     for ph in self.placeholders)
         if not self.placeholders:
             self.placeholders = defaults['placeholders']
 
@@ -149,12 +152,12 @@ class Cassette(object):
         self.interactions = [Interaction(i) for i in interactions]
 
         for i in self.interactions:
-            i.replace_all(self.placeholders, ('placeholder', 'replace'))
+            i.replace_all(self.placeholders, False)
             i.deserialize()  # this needs to happen *after* replace_all
 
     def sanitize_interactions(self):
         for i in self.interactions:
-            i.replace_all(self.placeholders)
+            i.replace_all(self.placeholders, True)
 
     def save_interaction(self, response, request):
         interaction = self.serialize_interaction(response, request)

--- a/betamax/cassette/cassette.py
+++ b/betamax/cassette/cassette.py
@@ -40,12 +40,13 @@ class Cassette(object):
         self.cassette_path = self.serializer.cassette_path
 
         # Determine which placeholders to use
-        self.placeholders = kwargs.get('placeholders')
-        if isinstance(self.placeholders, list):
-            self.placeholders = dict((ph['placeholder'], ph['replace'])
-                                     for ph in self.placeholders)
-        if not self.placeholders:
-            self.placeholders = defaults['placeholders']
+        self.placeholders = defaults['placeholders'].copy()
+        if kwargs.get('placeholders'):
+            if isinstance(kwargs['placeholders'], list):
+                for ph in kwargs['placeholders']:
+                    self.placeholders[ph['placeholder']] = ph['replace']
+            else:
+                self.placeholders.update(kwargs['placeholders'])
 
         # Determine whether to preserve exact body bytes
         self.preserve_exact_body_bytes = _option_from(

--- a/betamax/cassette/interaction.py
+++ b/betamax/cassette/interaction.py
@@ -52,11 +52,13 @@ class Interaction(object):
         self.replace_in_body(text_to_replace, placeholder)
         self.replace_in_uri(text_to_replace, placeholder)
 
-    def replace_all(self, replacements, key_order=('replace', 'placeholder')):
+    def replace_all(self, replacements, serializing):
         """Easy way to accept all placeholders registered."""
-        (replace_key, placeholder_key) = key_order
-        for r in replacements:
-            self.replace(r[replace_key], r[placeholder_key])
+        for placeholder, text_to_replace in replacements.items():
+            if serializing:
+                self.replace(text_to_replace, placeholder)
+            else:
+                self.replace(placeholder, text_to_replace)
 
     def replace_in_headers(self, text_to_replace, placeholder):
         for obj in ('request', 'response'):

--- a/betamax/configure.py
+++ b/betamax/configure.py
@@ -72,7 +72,4 @@ class Configuration(object):
         :param str replace: (required), text to be replaced or replacing the
             placeholder
         """
-        self.default_cassette_options['placeholders'].append({
-            'placeholder': placeholder,
-            'replace': replace
-        })
+        self.default_cassette_options['placeholders'][placeholder] = replace

--- a/betamax/options.py
+++ b/betamax/options.py
@@ -1,6 +1,10 @@
 from .cassette import Cassette
 
 
+def convert_placeholders_list(placeholders):
+    return dict((ph['placeholder'], ph['replace']) for ph in placeholders)
+
+
 def validate_record(record):
     return record in ['all', 'new_episodes', 'none', 'once']
 
@@ -17,10 +21,8 @@ def validate_serializer(serializer):
 
 
 def validate_placeholders(placeholders):
-    keys = ['placeholder', 'replace']
-    return all(
-        sorted(list(p.keys())) == keys for p in placeholders
-    )
+    """Validate placeholders is a dict-like structure"""
+    return hasattr(placeholders, 'items')
 
 
 def translate_cassette_options():
@@ -46,11 +48,14 @@ class Options(object):
         'serialize': None,  # TODO: Remove this
         'serialize_with': 'json',
         'preserve_exact_body_bytes': False,
-        'placeholders': [],
+        'placeholders': {},
     }
 
     def __init__(self, data=None):
         self.data = data or {}
+        if isinstance(data.get('placeholders'), list):
+            data['placeholders'] = \
+                    convert_placeholders_list(data['placeholders'])
         self.validate()
         self.defaults = Options.defaults.copy()
         self.defaults.update(translate_cassette_options())

--- a/betamax/recorder.py
+++ b/betamax/recorder.py
@@ -3,7 +3,7 @@ from . import matchers, serializers
 from .adapter import BetamaxAdapter
 from .cassette import Cassette
 from .configure import Configuration
-from .options import Options
+from .options import Options, convert_placeholders_list
 
 
 class Betamax(object):
@@ -55,6 +55,14 @@ class Betamax(object):
         self.betamax_adapter = BetamaxAdapter(old_adapters=self.http_adapters)
         # We need a configuration instance to make life easier
         self.config = Configuration()
+        try:
+            placeholders = default_cassette_options['placeholders']
+        except KeyError:
+            pass
+        else:
+            if isinstance(placeholders, list):
+                placeholders = convert_placeholders_list(placeholders)
+                default_cassette_options['placeholders'] = placeholders
         # Merge the new cassette options with the default ones
         self.config.default_cassette_options.update(
             default_cassette_options or {}

--- a/docs/configuring.rst
+++ b/docs/configuring.rst
@@ -244,14 +244,10 @@ example above and convert it.
     session = requests.Session()
 
     recorder = betamax.Betamax(session, default_cassette_options={
-        'placeholders': [
-            {
-                'placeholder': '<GITHUB-AUTH>',
-                'replace': base64.b64encode(
-                    '{0}:{1}'.format(username, password).encode('utf-8')
-                )
-            }
-        ]
+        'placeholders': {'<GITHUB-AUTH>': base64.b64encode(
+                '{0}:{1}'.format(username, password).encode('utf-8')
+            )
+        }
     })
 
 Note that what we passed as our first argument is assigned to the

--- a/tests/integration/test_placeholders.py
+++ b/tests/integration/test_placeholders.py
@@ -20,12 +20,7 @@ class TestPlaceholders(IntegrationHelper):
 
     def test_placeholders_work(self):
         placeholders = Cassette.default_cassette_options['placeholders']
-        placeholder = {
-            'placeholder': '<AUTHORIZATION>',
-            'replace': b64_foobar
-        }
-        assert placeholders != []
-        assert placeholder in placeholders
+        assert placeholders == {'<AUTHORIZATION>': b64_foobar}
 
         s = self.session
         cassette = None

--- a/tests/unit/test_cassette.py
+++ b/tests/unit/test_cassette.py
@@ -6,6 +6,7 @@ from datetime import datetime
 from betamax import __version__
 from betamax import cassette
 from betamax import mock_response
+from betamax import recorder
 from betamax import serializers
 from betamax import util
 from requests.models import Response, Request
@@ -180,6 +181,23 @@ class TestSerialization(unittest.TestCase):
         assert r.content == b'foo'
         assert isinstance(r.raw._original_response,
                           mock_response.MockHTTPResponse)
+
+
+def test_cassette_initialization():
+    serializers.serializer_registry['test'] = Serializer()
+
+    with recorder.Betamax.configure() as config:
+        config.define_cassette_placeholder('<TO-OVERRIDE>', 'default')
+        config.define_cassette_placeholder('<KEEP-DEFAULT>', 'config')
+        placeholders = {'<TO-OVERRIDE>': 'override', '<ONLY-OVERRIDE>': 'cassette'}
+        instance = cassette.Cassette('test_cassette', 'test', placeholders=placeholders)
+
+        expected = {
+                '<KEEP-DEFAULT>': 'config',
+                '<TO-OVERRIDE>': 'override',
+                '<ONLY-OVERRIDE>': 'cassette',
+        }
+        assert instance.placeholders == expected
 
 
 class TestCassette(unittest.TestCase):

--- a/tests/unit/test_configure.py
+++ b/tests/unit/test_configure.py
@@ -34,6 +34,7 @@ class TestConfiguration(unittest.TestCase):
     def test_allows_registration_of_placeholders(self):
         opts = copy.deepcopy(Cassette.default_cassette_options)
         c = Configuration()
+        c.default_cassette_options['placeholders'] = {}
 
         c.define_cassette_placeholder('<TEST>', 'test')
         assert opts != Cassette.default_cassette_options

--- a/tests/unit/test_configure.py
+++ b/tests/unit/test_configure.py
@@ -37,6 +37,4 @@ class TestConfiguration(unittest.TestCase):
 
         c.define_cassette_placeholder('<TEST>', 'test')
         assert opts != Cassette.default_cassette_options
-        placeholders = Cassette.default_cassette_options['placeholders']
-        assert placeholders[0]['placeholder'] == '<TEST>'
-        assert placeholders[0]['replace'] == 'test'
+        assert Cassette.default_cassette_options['placeholders'] == {'<TEST>': 'test'}

--- a/tests/unit/test_recorder.py
+++ b/tests/unit/test_recorder.py
@@ -18,6 +18,12 @@ class TestBetamax(unittest.TestCase):
             assert not isinstance(v, BetamaxAdapter)
             assert isinstance(v, HTTPAdapter)
 
+    def test_initialization_converts_placeholders(self):
+        placeholders = [{'placeholder': '<FOO>', 'replace': 'replace-with'}]
+        default_cassette_options = {'placeholders': placeholders}
+        self.vcr = Betamax(self.session, default_cassette_options=default_cassette_options)
+        assert self.vcr.config.default_cassette_options['placeholders'] == {'<FOO>': 'replace-with'}
+
     def test_entering_context_alters_adapters(self):
         with self.vcr:
             for v in self.session.adapters.values():
@@ -59,6 +65,11 @@ class TestBetamax(unittest.TestCase):
         assert self.session is self.vcr.session
 
     def test_use_cassette_passes_along_placeholders(self):
-        placeholders = [{'placeholder': '<FOO>', 'replace': 'replace-with'}]
+        placeholders = {'<FOO>': 'replace-with'}
         self.vcr.use_cassette('test', placeholders=placeholders)
         assert self.vcr.current_cassette.placeholders == placeholders
+
+    def test_use_cassette_converts_lists(self):
+        placeholders = [{'placeholder': '<FOO>', 'replace': 'replace-with'}]
+        self.vcr.use_cassette('test', placeholders=placeholders)
+        assert self.vcr.current_cassette.placeholders == {'<FOO>': 'replace-with'}


### PR DESCRIPTION
This changes the cassette placeholders parameter to always use the default cassette options and then replace any matching keys. To do so it first replaces the storage of placeholders from a list of dicts to a dict.

It maintains API compatibility so users don't have to modify their tests, but because of the merging it could invalidate existing cassettes.

Another issue is that Cassette.default_cassette_options is a class variable meaning you can't remove any global config keys. This could be solved by moving the defaults to the configuration and passing it in the constructor.

Closes GH-97