### PR TITLE
Allow to record duplicated urls on a cassette

### DIFF
--- a/betamax/cassette/cassette.py
+++ b/betamax/cassette/cassette.py
@@ -109,6 +109,10 @@ class Cassette(object):
         :param request: ``requests.PreparedRequest``
         :returns: :class:`Interaction <Interaction>`
         """
+        # if we are recording, do not filter by match
+        if self.is_recording():
+            return None
+
         opts = self.match_options
         # Curry those matchers
         curried_matchers = [
@@ -118,12 +122,15 @@ class Cassette(object):
 
         for i in self.interactions:
             # If the interaction matches everything
-            if i.match(curried_matchers):
+            if i.match(curried_matchers) and not i.used:
                 if self.record_mode == 'all':
                     # If we're recording everything and there's a matching
                     # interaction we want to overwrite it, so we remove it.
                     self.interactions.remove(i)
                     break
+
+                # set interaction as used before returning
+                i.used = True
                 return i
 
         # No matches. So sad.

--- a/betamax/cassette/interaction.py
+++ b/betamax/cassette/interaction.py
@@ -25,6 +25,7 @@ class Interaction(object):
         self.recorded_at = None
         self.json = interaction
         self.orig_response = response
+        self.used = False
         self.deserialize()
 
     def as_response(self):

--- a/tests/cassettes/test_replays_response_on_right_order.json
+++ b/tests/cassettes/test_replays_response_on_right_order.json
@@ -1,0 +1,63 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2013-12-22T16:30:30",
+      "response": {
+        "headers": {
+          "server": "gunicorn/0.17.4",
+          "access-control-allow-origin": "*",
+          "date": "Sun, 22 Dec 2013 16:31:13 GMT",
+          "connection": "keep-alive",
+          "content-type": "application/json",
+          "content-length": "295"
+        },
+        "status_code": 200,
+        "body": {
+          "string": "{\n  \"headers\": {\n    \"Accept-Encoding\": \"gzip, deflate, compress\",\n    \"Accept\": \"*/*\",\n    \"Host\": \"httpbin.org\",\n    \"User-Agent\": \"python-requests/2.0.0 CPython/3.3.2 Linux/3.2.29\",\n    \"Connection\": \"close\"\n  },\n  \"origin\": \"72.160.214.132\",\n  \"args\": {},\n  \"url\": \"http://httpbin.org/get\"\n}",
+          "encoding": null
+        },
+        "url": "http://httpbin.org/get"
+      },
+      "request": {
+        "method": "GET",
+        "headers": {
+          "Accept-Encoding": "gzip, deflate, compress",
+          "Accept": "*/*",
+          "User-Agent": "python-requests/2.0.0 CPython/3.3.2 Linux/3.2.29"
+        },
+        "uri": "http://httpbin.org/get",
+        "body": ""
+      }
+    },
+    {
+      "recorded_at": "2013-12-22T16:30:30",
+      "response": {
+        "headers": {
+          "server": "gunicorn/0.17.4",
+          "access-control-allow-origin": "*",
+          "date": "Sun, 22 Dec 2013 16:31:13 GMT",
+          "connection": "keep-alive",
+          "content-type": "application/json",
+          "content-length": "295"
+        },
+        "status_code": 200,
+        "body": {
+          "string": "{\n  \"headers\": {\n    \"Accept-Encoding\": \"gzip, deflate, compress\",\n    \"Accept\": \"*/*\",\n    \"Host\": \"httpbin.org\",\n    \"User-Agent\": \"python-requests/2.0.0 CPython/3.3.2 Linux/3.2.29\",\n    \"Connection\": \"close\"\n  },\n  \"origin\": \"72.160.214.133\",\n  \"args\": {},\n  \"url\": \"http://httpbin.org/get\"\n}",
+          "encoding": null
+        },
+        "url": "http://httpbin.org/get"
+      },
+      "request": {
+        "method": "GET",
+        "headers": {
+          "Accept-Encoding": "gzip, deflate, compress",
+          "Accept": "*/*",
+          "User-Agent": "python-requests/2.0.0 CPython/3.3.2 Linux/3.2.29"
+        },
+        "uri": "http://httpbin.org/get",
+        "body": ""
+      }
+    }
+  ],
+  "recorded_with": "betamax"
+}

--- a/tests/integration/test_record_modes.py
+++ b/tests/integration/test_record_modes.py
@@ -24,7 +24,7 @@ class TestRecordOnce(IntegrationHelper):
             assert betamax.current_cassette.interactions != []
             assert len(betamax.current_cassette.interactions) == 1
             r1 = s.get('http://httpbin.org/get')
-            assert len(betamax.current_cassette.interactions) == 1
+            assert len(betamax.current_cassette.interactions) == 2
             assert r1.status_code == 200
             assert r0.headers == r1.headers
             assert r0.content == r1.content
@@ -61,14 +61,14 @@ class TestRecordNewEpisodes(IntegrationHelper):
             cassette = betamax.current_cassette
             self.cassette_path = cassette.cassette_path
             assert cassette.interactions != []
-            assert len(cassette.interactions) == 3
+            assert len(cassette.interactions) == 4
             assert cassette.is_empty() is False
             s.get('https://httpbin.org/get')
-            assert len(cassette.interactions) == 4
+            assert len(cassette.interactions) == 5
 
         with Betamax(s).use_cassette('test_record_new') as betamax:
             cassette = betamax.current_cassette
-            assert len(cassette.interactions) == 4
+            assert len(cassette.interactions) == 5
             r = s.get('https://httpbin.org/get')
             assert r.status_code == 200
 
@@ -97,22 +97,10 @@ class TestRecordAll(IntegrationHelper):
             cassette = betamax.current_cassette
             self.cassette_path = cassette.cassette_path
             assert cassette.interactions != []
-            assert len(cassette.interactions) == 3
+            assert len(cassette.interactions) == 4
             assert cassette.is_empty() is False
             s.post('http://httpbin.org/post', data={'foo': 'bar'})
-            assert len(cassette.interactions) == 4
+            assert len(cassette.interactions) == 5
 
         with Betamax(s).use_cassette('test_record_all') as betamax:
-            assert len(betamax.current_cassette.interactions) == 4
-
-    def test_replaces_old_interactions(self):
-        s = self.session
-        opts = {'record': 'all'}
-        with Betamax(s).use_cassette('test_record_all', **opts) as betamax:
-            cassette = betamax.current_cassette
-            self.cassette_path = cassette.cassette_path
-            assert cassette.interactions != []
-            assert len(cassette.interactions) == 3
-            assert cassette.is_empty() is False
-            s.get('http://httpbin.org/get')
-            assert len(cassette.interactions) == 3
+            assert len(betamax.current_cassette.interactions) == 5

--- a/tests/unit/test_cassette.py
+++ b/tests/unit/test_cassette.py
@@ -275,6 +275,7 @@ class TestCassette(unittest.TestCase):
 
     def test_find_match(self):
         self.cassette.match_options = set(['uri', 'method'])
+        self.cassette.record_mode = 'none'
         i = self.cassette.find_match(self.response.request)
         assert i is not None
         assert self.interaction is i

--- a/tests/unit/test_replays.py
+++ b/tests/unit/test_replays.py
@@ -1,0 +1,21 @@
+from betamax import Betamax, BetamaxError
+from requests import Session
+
+import unittest
+
+
+class TestReplays(unittest.TestCase):
+    def setUp(self):
+        self.session = Session()
+
+    def test_replays_response_on_right_order(self):
+        s = self.session
+        opts = {'record': 'none'}
+        with Betamax(s).use_cassette('test_replays_response_on_right_order', **opts) as betamax:
+            self.cassette_path = betamax.current_cassette.cassette_path
+            r0 = s.get('http://httpbin.org/get')
+            r1 = s.get('http://httpbin.org/get')
+            r0_found = (b'72.160.214.132' in r0.content)
+            assert r0_found == True
+            r1_found = (b'72.160.214.133' in r1.content)
+            assert r1_found == True


### PR DESCRIPTION
Currently betamax doesn't allow to record two exact urls under the same cassette. It is always picking the latest url that is recorded. This can break use case for several tests.
Updated the behaviour to allow to record duplicated content, then updated the consumer logic to pick the same urls by order.