### PR TITLE
Add regression test for requests 2.11.

### DIFF
--- a/tests/regression/test_requests_2_11_body_matcher.py
+++ b/tests/regression/test_requests_2_11_body_matcher.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+
+from betamax import Betamax
+from requests import Session
+
+
+class TestRequests211BodyMatcher(unittest.TestCase):
+    def tearDown(self):
+        os.unlink('tests/cassettes/requests_2_11_body_matcher.json')
+
+    def test_requests_with_json_body(self):
+        s = Session()
+        with Betamax(s).use_cassette('requests_2_11_body_matcher',
+                                     match_requests_on=['body']):
+            r = s.post('https://httpbin.org/post', json={'a': 2})
+            assert r.json() is not None
+
+        s = Session()
+        with Betamax(s).use_cassette('requests_2_11_body_matcher',
+                                     match_requests_on=['body']):
+            r = s.post('https://httpbin.org/post', json={'a': 2})
+            assert r.json() is not None


### PR DESCRIPTION
I thought #114 would be a quick fix, however, I was wrong. This is the start which adds a regression test to demonstrate the issue.

From my observation it would seem that with python3+ the actual request body will always be of type bytes. The cassette will always store utf-8, so the request/response body that is read in from the cassette should be converted to bytes. This is different than the code (some of which I previously added) does.

Unfortunately, I don't have more time tonight to look into it.