### PR TITLE
Handle differences in Requests 2.11.0

### DIFF
--- a/betamax/matchers/body.py
+++ b/betamax/matchers/body.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 from .base import BaseMatcher
-from betamax.util import deserialize_prepared_request
+
+from betamax import util
 
 
 class BodyMatcher(BaseMatcher):
@@ -8,14 +9,14 @@ class BodyMatcher(BaseMatcher):
     name = 'body'
 
     def match(self, request, recorded_request):
-        recorded_request = deserialize_prepared_request(recorded_request)
+        recorded_request = util.deserialize_prepared_request(recorded_request)
 
+        request_body = b''
         if request.body:
-            if isinstance(recorded_request.body, type(request.body)):
-                request_body = request.body
-            else:
-                request_body = request.body.encode('utf-8')
-        else:
-            request_body = b''
+            request_body = util.coerce_content(request.body)
 
-        return recorded_request.body == request_body
+        recorded_body = b''
+        if recorded_request.body:
+            recorded_body = util.coerce_content(recorded_request.body)
+
+        return recorded_body == request_body

--- a/tests/regression/test_requests_2_11_body_matcher.py
+++ b/tests/regression/test_requests_2_11_body_matcher.py
@@ -1,0 +1,23 @@
+import os
+import unittest
+
+from betamax import Betamax
+from requests import Session
+
+
+class TestRequests211BodyMatcher(unittest.TestCase):
+    def tearDown(self):
+        os.unlink('tests/cassettes/requests_2_11_body_matcher.json')
+
+    def test_requests_with_json_body(self):
+        s = Session()
+        with Betamax(s).use_cassette('requests_2_11_body_matcher',
+                                     match_requests_on=['body']):
+            r = s.post('https://httpbin.org/post', json={'a': 2})
+            assert r.json() is not None
+
+        s = Session()
+        with Betamax(s).use_cassette('requests_2_11_body_matcher',
+                                     match_requests_on=['body']):
+            r = s.post('https://httpbin.org/post', json={'a': 2})
+            assert r.json() is not None

--- a/tests/regression/test_requests_2_11_body_matcher.py
+++ b/tests/regression/test_requests_2_11_body_matcher.py
@@ -1,22 +1,26 @@
 import os
 import unittest
 
+import pytest
+import requests
+
 from betamax import Betamax
-from requests import Session
 
 
 class TestRequests211BodyMatcher(unittest.TestCase):
     def tearDown(self):
         os.unlink('tests/cassettes/requests_2_11_body_matcher.json')
 
+    @pytest.mark.skipif(requests.__build__ < 0x020401,
+                        reason="No json keyword.")
     def test_requests_with_json_body(self):
-        s = Session()
+        s = requests.Session()
         with Betamax(s).use_cassette('requests_2_11_body_matcher',
                                      match_requests_on=['body']):
             r = s.post('https://httpbin.org/post', json={'a': 2})
             assert r.json() is not None
 
-        s = Session()
+        s = requests.Session()
         with Betamax(s).use_cassette('requests_2_11_body_matcher',
                                      match_requests_on=['body']):
             r = s.post('https://httpbin.org/post', json={'a': 2})


### PR DESCRIPTION
Compare bodies appropriately by ensuring both the request body and the recorded body are coerced to bytestrings.

Closes #115 
Closes #114 

cc @bboe. This seems to pass with your regression test on both Requests 2.10.0 and 2.11.0. I'd love your review